### PR TITLE
Add functionality to play songs sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,34 @@ A Python-based music scheduling application with a modern GUI that allows users 
   
 ```bash
 pip install pygame schedule
+```
 
-Installation
-Clone this repository
-Install the required packages
-Run music_scheduler.py
-Usage
-Select a music folder containing MP3 or WAV files
-Choose the desired time for playback
-Select the days you want the music to play
-Adjust the volume as needed
-Click "Add Schedule" to create a new schedule
-Your schedules will be saved automatically
-Configuration
-The application saves its settings in music_scheduler_settings.json in the same directory as the application.
+## Installation
 
-Contributing
+1. Clone this repository
+2. Install the required packages
+3. Run `music_scheduler.py`
+
+## Usage
+
+1. Select a music folder containing MP3 or WAV files
+2. Choose the desired time for playback
+3. Select the days you want the music to play
+4. Adjust the volume as needed
+5. Click "Add Schedule" to create a new schedule
+6. Your schedules will be saved automatically
+7. Use the "Shuffle and Play" button to play songs one after the other in random order
+
+## Configuration
+
+The application saves its settings in `music_scheduler_settings.json` in the same directory as the application.
+
+## Contributing
+
 Feel free to open issues or submit pull requests with improvements.
 
-License
-This project is licensed under the MIT License - see the LICENSE file for details.
+## License
 
+This project is licensed under the MIT License - see the LICENSE file for details.
 
 This README provides a clear overview of your application, its features, setup instructions, and basic usage guidelines. You can modify it further based on any specific details or requirements you'd like to add.

--- a/music_scheduler.py
+++ b/music_scheduler.py
@@ -625,12 +625,9 @@ class MusicSchedulerApp:
                                  if f.endswith(('.mp3', '.wav'))]
                     print(f"Found {len(music_files)} music files")
                     if music_files:
-                        music_file = os.path.join(schedule_info['folder'], 
-                                                random.choice(music_files))
-                        print(f"Playing: {music_file}")
-                        pygame.mixer.music.load(music_file)
-                        pygame.mixer.music.play()
-                        self.status_label.config(text=f"מנגן: {os.path.basename(music_file)}")
+                        self.music_files = music_files
+                        self.current_music_index = 0
+                        self.play_next_song(schedule_info['folder'])
                     else:
                         print("No music files found")
                         self.status_label.config(text="לא נמצאו קבצי מוזיקה")
@@ -676,14 +673,32 @@ class MusicSchedulerApp:
                           if f.endswith(('.mp3', '.wav'))]
             if music_files:
                 random.shuffle(music_files)
-                music_file = os.path.join(self.music_folder, music_files[0])
-                pygame.mixer.music.load(music_file)
-                pygame.mixer.music.play()
-                self.status_label.config(text=f"מנגן: {os.path.basename(music_file)}")
+                self.music_files = music_files
+                self.current_music_index = 0
+                self.play_next_song(self.music_folder)
             else:
                 messagebox.showerror("שגיאה", "לא נמצאו קבצי מוזיקה בתיקייה")
         except Exception as e:
             messagebox.showerror("שגיאה", f"שגיאה בהפעלת המוזיקה: {str(e)}")
+
+    def play_next_song(self, folder):
+        """Function to play the next song in the list"""
+        if self.current_music_index < len(self.music_files):
+            music_file = os.path.join(folder, self.music_files[self.current_music_index])
+            pygame.mixer.music.load(music_file)
+            pygame.mixer.music.play()
+            self.status_label.config(text=f"מנגן: {os.path.basename(music_file)}")
+            self.current_music_index += 1
+            pygame.mixer.music.set_endevent(pygame.USEREVENT)
+            pygame.event.clear()
+            while True:
+                for event in pygame.event.get():
+                    if event.type == pygame.USEREVENT:
+                        self.play_next_song(folder)
+                        return
+                time.sleep(0.1)
+        else:
+            self.status_label.config(text="סיימנו לנגן את כל השירים")
 
     def update_day_selection(self, day):
         """עדכון חיווי ויזואלי לבחירת יום"""


### PR DESCRIPTION
Modify the `play_music` function to play songs one after the other.

* **music_scheduler.py**
  - Replace the logic to select and play a random song with logic to initialize the list of music files and start playing the first song.
  - Add a new function `play_next_song` to handle playing the next song in the list.
  - Update the `shuffle_and_play` function to use the new `play_next_song` function.

* **README.md**
  - Update the usage instructions to reflect the new functionality of playing songs one after the other in random order.
  - Reformat the installation and usage sections for better clarity.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tzviki1304/music_scheduler/pull/1?shareId=8597562a-e2e2-48c4-b3d2-0e38eec691a3).